### PR TITLE
Add convertToOWL() to FrextToBioPAX

### DIFF
--- a/convertor/src/main/java/org/pathwaycommons/pathwaycards/convertor/FrextToBioPAX.java
+++ b/convertor/src/main/java/org/pathwaycommons/pathwaycards/convertor/FrextToBioPAX.java
@@ -637,6 +637,11 @@ public class FrextToBioPAX
 		io.convertToOWL(model, new FileOutputStream(filename));
 	}
 
+	public String convertToOWL()
+	{
+		return SimpleIOHandler.convertToOwl(model);
+	}
+
 	/**
 	 * Make sure that directories are not nested. Otherwise duplications will happen.
 	 * @param dirs


### PR DESCRIPTION
Added ```convertToOWL() ``` to ```FrextToBioPAX```. ```convertToOWL() ``` returns OWL representation of the model as String by calling ```SimpleIOHandler.convertToOwl(model)```