### PR TITLE
Add mising converter module to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,5 +26,6 @@
 		<module>nlp</module>
 		<module>extractor</module>
 		<module>comparator</module>
+    <module>convertor</module>
 	</modules>
 </project>


### PR DESCRIPTION
Adds the missing converter module to the main ```pom.xml```.